### PR TITLE
Clarify enterprise usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Override the github api url
 github-org-clone -o MyOrg -a https://mycustomdomain.com
 ```
 
+For enterprise installations include the full path to the github api
+
+```bash
+github-org-clone -o MyOrg -a https://mycustomdomain.com/api/v3
+```
+
 View docs
 
 ```bash


### PR DESCRIPTION
Pointing the tool at the enterprise website isn't enough. The full api url needs to be used.
It's possible the "Override the github api url" section is meant to convey that, but it's not clear. If so, we can merge the two sections.